### PR TITLE
Allow building from vite  - fix type script error

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1,6 +1,6 @@
 import Observer from "./socket-server/Observer";
 import Emitter from "./socket-server/Emitter";
-import { websocketOpts } from "@/type/PluginsType";
+import { websocketOpts } from "./type/PluginsType";
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { App } from "vue";


### PR DESCRIPTION
vite does not allow the @ alias by default like webpack.

```
> vue-tsc --noEmit && vite build

node_modules/vue-native-websocket-vue3/dist/lib/main.d.ts:1:31 - error TS2307: Cannot find module '@/type/PluginsType' or its corresponding type declarations.

1 import { websocketOpts } from "@/type/PluginsType";
                                ~~~~~~~~~~~~~~~~~~~~
```

Changing: 
`import { websocketOpts } from "@/type/PluginsType";`
to
`import { websocketOpts } from "./type/PluginsType";`

This change should work for both (confirmed it works for vite)